### PR TITLE
Fix the initializer's bug: could not launch any rails command with the gem

### DIFF
--- a/lib/rakuten_web_service/rails.rb
+++ b/lib/rakuten_web_service/rails.rb
@@ -11,6 +11,8 @@ module RakutenWebService
     end
 
     def load_configuration(config_path, environment)
+      return unless File.exists? config_path
+
       config = YAML.load(ERB.new(File.read(config_path)).result(binding))[environment]
       if config
         RakutenWebService.configure do |c|

--- a/spec/rakuten_web_service/rails_spec.rb
+++ b/spec/rakuten_web_service/rails_spec.rb
@@ -49,5 +49,15 @@ describe RakutenWebService::Railtie do
         end
       end
     end
+
+    context "When the configuration file doesn't exist" do
+      let(:config_path) { '/path/to/wrong_file.yml' }
+
+      it "should not raise any error when loading the configuration" do
+        expect {
+          RakutenWebService::Railtie.instance.load_configuration(config_path, 'test')
+        }.to_not raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
When tried to use the generator provided by this gem in a rails app, I could not use it due to the following error arose: 

```
/Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/rakuten_web_service-rails-b54f1955b4e5/lib/rakuten_web_service/rails.rb:14:in `read': No such file or directory @ rb_sysopen - /Users/tatsuya.b.sato/Projects/work/rws-ruby-sdk-rails-sample/config/rakuten_web_service.yml (Errno::ENOENT)
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/rakuten_web_service-rails-b54f1955b4e5/lib/rakuten_web_service/rails.rb:14:in `load_configuration'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bundler/gems/rakuten_web_service-rails-b54f1955b4e5/lib/rakuten_web_service/rails.rb:10:in `block in <class:Railtie>'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/railties-4.2.5/lib/rails/initializable.rb:30:in `instance_exec'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/railties-4.2.5/lib/rails/initializable.rb:30:in `run'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/railties-4.2.5/lib/rails/initializable.rb:55:in `block in run_initializers'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:228:in `block in tsort_each'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:431:in `each_strongly_connected_component_from'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:349:in `block in each_strongly_connected_component'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:347:in `each'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:347:in `call'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:347:in `each_strongly_connected_component'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:226:in `tsort_each'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/2.3.0/tsort.rb:205:in `tsort_each'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/railties-4.2.5/lib/rails/initializable.rb:54:in `run_initializers'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/railties-4.2.5/lib/rails/application.rb:352:in `initialize!'
        from /Users/tatsuya.b.sato/Projects/work/rws-ruby-sdk-rails-sample/config/environment.rb:5:in `<top (required)>'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.4.0/lib/spring/application.rb:92:in `require'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.4.0/lib/spring/application.rb:92:in `preload'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.4.0/lib/spring/application.rb:143:in `serve'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.4.0/lib/spring/application.rb:131:in `block in run'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.4.0/lib/spring/application.rb:125:in `loop'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.4.0/lib/spring/application.rb:125:in `run'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/spring-1.4.0/lib/spring/application/boot.rb:18:in `<top (required)>'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /Users/tatsuya.b.sato/.rbenv/versions/2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from -e:1:in `<main>'
```

The generate must be able to be used from Rails app without configuration file for `rakuten_web_service` . 